### PR TITLE
fix bad custom error generation

### DIFF
--- a/lib/http-error.js
+++ b/lib/http-error.js
@@ -16,7 +16,7 @@ module.exports.HttpError = HttpError;
  */
 
 function httpErrorFactory(status, message) {
-  return function httpError(req, res, next) {
+  return function httpErrorMiddleware(req, res, next) {
     next(new HttpError(status, message));
   };
 }
@@ -29,9 +29,16 @@ function httpErrorFactory(status, message) {
  */
 
 function HttpError(status, message) {
-  Error.call(this);
-  this.status = status;
+  // Import everything needed into 'this' so it "duck type" an Error object.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
+  this.name = 'HttpError';
   this.message = message || statusCodes[status];
+  this.stack = (new Error()).stack;
+
+  this.status = status; // non-standard : hint at http status code
 }
 
-util.inherits(HttpError, Error);
+// REM "Error" always returns a new object
+// cf. http://www.ecma-international.org/ecma-262/5.1/#sec-15.11.1
+HttpError.prototype = Object.create(Error.prototype);
+HttpError.prototype.constructor = HttpError;

--- a/test/http-error.js
+++ b/test/http-error.js
@@ -7,16 +7,18 @@ var expect = require('chai').expect;
 describe('HttpError constructor', function () {
   it('should create an error with message and status', function () {
     var error = new HttpError(401, 'my message');
-    expect(error).to.have.property('status', 401);
+    expect(error).to.have.property('name', 'HttpError');
     expect(error).to.have.property('message', 'my message');
     expect(error).to.have.property('stack');
+    expect(error).to.have.property('status', 401);
   });
 
   it('should default message to http status', function () {
     var error = new HttpError(404);
-    expect(error).to.have.property('status', 404);
+    expect(error).to.have.property('name', 'HttpError');
     expect(error).to.have.property('message', 'Not Found');
     expect(error).to.have.property('stack');
+    expect(error).to.have.property('status', 404);
   });
 });
 
@@ -32,9 +34,10 @@ describe('httpError middleware', function () {
 
     app.use(function (err, req, res, next) {
       expect(err).to.be.instanceof(Error);
-      expect(err).to.have.property('status', 404);
+      expect(err).to.have.property('name', 'HttpError');
       expect(err).to.have.property('message', 'Not Found');
       expect(err).to.have.property('stack');
+      expect(err).to.have.property('status', 404);
       done();
     });
 
@@ -46,9 +49,10 @@ describe('httpError middleware', function () {
 
     app.use(function (err, req, res, next) {
       expect(err).to.be.instanceof(Error);
-      expect(err).to.have.property('status', 408);
+      expect(err).to.have.property('name', 'HttpError');
       expect(err).to.have.property('message', 'Custom error message.');
       expect(err).to.have.property('stack');
+      expect(err).to.have.property('status', 408);
       done();
     });
 

--- a/test/http-error.js
+++ b/test/http-error.js
@@ -9,12 +9,14 @@ describe('HttpError constructor', function () {
     var error = new HttpError(401, 'my message');
     expect(error).to.have.property('status', 401);
     expect(error).to.have.property('message', 'my message');
+    expect(error).to.have.property('stack');
   });
 
   it('should default message to http status', function () {
     var error = new HttpError(404);
     expect(error).to.have.property('status', 404);
     expect(error).to.have.property('message', 'Not Found');
+    expect(error).to.have.property('stack');
   });
 });
 
@@ -32,6 +34,7 @@ describe('httpError middleware', function () {
       expect(err).to.be.instanceof(Error);
       expect(err).to.have.property('status', 404);
       expect(err).to.have.property('message', 'Not Found');
+      expect(err).to.have.property('stack');
       done();
     });
 
@@ -45,6 +48,7 @@ describe('httpError middleware', function () {
       expect(err).to.be.instanceof(Error);
       expect(err).to.have.property('status', 408);
       expect(err).to.have.property('message', 'Custom error message.');
+      expect(err).to.have.property('stack');
       done();
     });
 


### PR DESCRIPTION
The new custom error `HttpError` doesn't behave as an error, mainly by missing properties `stack` and `name`.

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
* http://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript